### PR TITLE
Near deposits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,9 +251,9 @@ checksum = "8452105ba047068f40ff7093dd1d9da90898e63dd61736462e9cdda6a90ad3c3"
 
 [[package]]
 name = "near-contract-standards"
-version = "4.0.0-pre.2"
+version = "4.0.0-pre.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0bedf701e9a9b3a2df683cb5b7360d95492e70239a380e1e604745d2290e65f"
+checksum = "557388f4de72fa16ca1e2c8c368f8343f077c5d284d043e93be76a3b7e737872"
 dependencies = [
  "near-sdk",
 ]
@@ -315,9 +315,9 @@ dependencies = [
 
 [[package]]
 name = "near-sdk"
-version = "4.0.0-pre.2"
+version = "4.0.0-pre.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab7fc853396919d12055cc4051c303758a75ebca74223f5c9e0907a549452cc3"
+checksum = "10f570e260eae9169dd5ffe0764728b872c2df79b8786dfb5e57183bd383908e"
 dependencies = [
  "base64",
  "borsh",
@@ -333,9 +333,9 @@ dependencies = [
 
 [[package]]
 name = "near-sdk-macros"
-version = "4.0.0-pre.2"
+version = "4.0.0-pre.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44fcbacb1d2fedcb2e4aa05094d31ccbfa831c868ca1242d1345b3e45c6b8a6c"
+checksum = "65ddca18086f1ab14ce8541e0c23f503a322d45914f2fe08f571844045d32bde"
 dependencies = [
  "Inflector",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,8 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 uint = { version = "0.9.0", default-features = false }
-near-sdk = { version = "4.0.0-pre.2" }
-near-contract-standards = "4.0.0-pre.2"
+near-sdk = { version = "4.0.0-pre.3" }
+near-contract-standards = "4.0.0-pre.3"
 
 [profile.release]
 codegen-units = 1

--- a/build_local.sh
+++ b/build_local.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -e
 
-RUSTFLAGS='-C link-arg=-s' cargo +stable build --target wasm32-unknown-unknown --release
+RUSTFLAGS='-C link-arg=-s' cargo build --target wasm32-unknown-unknown --release
 cp target/wasm32-unknown-unknown/release/fundraiser.wasm ./res/fundraiser_local.wasm

--- a/src/sale.rs
+++ b/src/sale.rs
@@ -13,8 +13,6 @@ use crate::*;
 const ONE_YOCTO: Balance = 1;
 const GAS_NEAR_DEPOSIT: Gas = BASE_GAS;
 const GAS_AFTER_FT_ON_TRANSFER_NEAR_DEPOSIT: Gas = Gas(40_000_000_000_000);
-const GAS_GET_ACCOUNT_STAKED_BALANCE: Gas = Gas(25_000_000_000_000);
-const GAS_ON_GET_ACCOUNT_STAKED_BALANCE: Gas = Gas(25_000_000_000_000);
 
 #[ext_contract(ext_wrap_near)]
 pub trait ExtWrapNear {
@@ -252,7 +250,7 @@ impl Contract {
         if wrap_amount > 0 {
             // Assuming it will succeed
             ext_wrap_near::near_deposit(
-                &AccountId::new_unchecked(WRAP_NEAR_ACCOUNT.to_string()),
+                AccountId::new_unchecked(WRAP_NEAR_ACCOUNT.to_string()),
                 wrap_amount,
                 GAS_NEAR_DEPOSIT,
             );
@@ -284,7 +282,7 @@ impl Contract {
                 ))
                 .into(),
             PromiseOrValue::Value(value) => {
-                ext_self::internal_after_ft_on_transfer_near_deposit(value.0, sender_id, amount)
+                self.internal_finalize_near_deposit(value.0, sender_id, amount)
             }
         }
     }


### PR DESCRIPTION
- simplify near deposits by assuming the contract already has the wnear token and wrapping required amount at the end